### PR TITLE
C++ standard set to 11 and lua requirement removed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(felt_VERSION_MICRO 1)
 set(X11DEF_DIR "/etc/X11/app-defaults" CACHE PATH "install directory for X11 resource files.")
 configure_file(include/config.h.in include/config.h)
 
-set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD 11)
 
 find_program(CPP_LOCATION cpp)
 if(NOT CPP_LOCATION)
@@ -19,7 +19,6 @@ find_package(FLEX REQUIRED)
 find_package(BISON REQUIRED)
 find_package(Boost 1.40.0)
 include_directories(${Boost_INCLUDE_DIRS})
-find_package(Lua51 REQUIRED)
 
 include_directories(include)
 add_subdirectory(lib)


### PR DESCRIPTION
Requirement of Lua package was removed since we are not using lua language anymore.